### PR TITLE
Adding CI/CD build

### DIFF
--- a/workflows/main.yml
+++ b/workflows/main.yml
@@ -1,0 +1,23 @@
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-full-node:
+    runs-on: ubuntu-latest
+    permissions:
+        packages: write
+        contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build image
+        run: |
+          cd images/full-node
+          docker build -f Dockerfile . -t chompchain-full:latest
+      - name: Log in to container registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+      - name: Publish image
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/chompchain-full
+          docker tag chompchain-full:latest $IMAGE_ID:latest
+          docker push $IMAGE_ID:latest


### PR DESCRIPTION
Adding CI/CD steps to build the container on GitHub for deployment to production instances.