### PR TITLE
Adding cron job for chain generation

### DIFF
--- a/images/full-node/crontab
+++ b/images/full-node/crontab
@@ -1,2 +1,1 @@
-TZ = America/New_York
-* * * * * root echo "cron -- $(date)" >> /var/log/cron.log 2>&1
+0 * * * * root chompchain --generate

--- a/images/full-node/crontab
+++ b/images/full-node/crontab
@@ -1,1 +1,1 @@
-0 * * * * root chompchain --generate
+0 * * * * chompers chompchain --generate


### PR DESCRIPTION
Updating `cron` job for block generation. In reality, this will go away once we decentralize the network, but we need it to test the mechanics.