### PR TITLE
Migrating PM2 config to allow cron to access memory pool

### DIFF
--- a/images/full-node/Dockerfile
+++ b/images/full-node/Dockerfile
@@ -40,6 +40,8 @@ RUN source ~/.bashrc
 RUN nvm install 16.10.0 && nvm use 16.10.0
 # Install pm2 process manager
 RUN npm install pm2 --global
+# Create pm2 group
+RUN groupadd pm2
 
 RUN mkdir /opt/server/
 
@@ -91,6 +93,13 @@ RUN useradd chompers
 RUN mkdir /home/chompers
 RUN chown chompers:chompers /home/chompers -R
 RUN usermod -d /home/chompers chompers
+RUN usermod -aG pm2 chompers
+
+RUN mkdir /opt/pm2
+RUN chgrp -R pm2 /opt/pm2
+RUN chmod -R 770 /opt/pm2
+
+RUN chown root:pm2 /mempool -R
 
 ADD crontab /etc/cron.d/sweep-transactions
 RUN chmod 0644 /etc/cron.d/sweep-transactions

--- a/images/full-node/entrypoint.sh
+++ b/images/full-node/entrypoint.sh
@@ -5,6 +5,7 @@ source ~/.bashrc
 
 # CouchDB startup
 service couchdb start
+cron
 sleep 5
 
 # Create environment variables for DB user
@@ -48,9 +49,4 @@ curl -s -o /dev/null -X PUT --user admin:$COUCHDB_PASSWORD http://127.0.0.1:5984
 
 # pm2 task
 echo "Kick off project daemons..."
-pm2-runtime /opt/server/chompchain-node/nodes/ecosystem.config.js --only "validator, registry"
-
-# Transfer away from root user
-gosu chompers /bin/bash
-# TODO: Verify that this can run without apparent error
-##gosu chompers python -c "import chompchain"
+gosu chompers PM2_HOME=/opt/pm2 pm2-runtime /opt/server/chompchain-node/nodes/ecosystem.config.js --only "validator, registry"


### PR DESCRIPTION
As title suggests, we need to centralize operations in the container to run as an interoperable `pm2` group.