### PR TITLE
Removing pm2 setup; write sticky bit instead?

### DIFF
--- a/images/full-node/Dockerfile
+++ b/images/full-node/Dockerfile
@@ -40,8 +40,6 @@ RUN source ~/.bashrc
 RUN nvm install 16.10.0 && nvm use 16.10.0
 # Install pm2 process manager
 RUN npm install pm2 --global
-# Create pm2 group
-RUN groupadd pm2
 
 RUN mkdir /opt/server/
 
@@ -51,6 +49,9 @@ RUN cd /opt/server/chompchain-node/nodes/ && npm install
 RUN cd /opt/server/chompchain-node/ && python3 -m pip install -r requirements.txt
 
 RUN mkdir /$TXPOOL
+RUN groupadd chain
+RUN chown root:chain /mempool -R
+RUN chmod g+ws /mempool
 
 RUN curl https://couchdb.apache.org/repo/keys.asc | gpg --dearmor | sudo tee /usr/share/keyrings/couchdb-archive-keyring.gpg >/dev/null 2>&1
 RUN source /etc/os-release
@@ -93,13 +94,7 @@ RUN useradd chompers
 RUN mkdir /home/chompers
 RUN chown chompers:chompers /home/chompers -R
 RUN usermod -d /home/chompers chompers
-RUN usermod -aG pm2 chompers
-
-RUN mkdir /opt/pm2
-RUN chgrp -R pm2 /opt/pm2
-RUN chmod -R 770 /opt/pm2
-
-RUN chown root:pm2 /mempool -R
+RUN usermod -aG chain chompers
 
 ADD crontab /etc/cron.d/sweep-transactions
 RUN chmod 0644 /etc/cron.d/sweep-transactions

--- a/images/full-node/entrypoint.sh
+++ b/images/full-node/entrypoint.sh
@@ -49,4 +49,4 @@ curl -s -o /dev/null -X PUT --user admin:$COUCHDB_PASSWORD http://127.0.0.1:5984
 
 # pm2 task
 echo "Kick off project daemons..."
-gosu chompers PM2_HOME=/opt/pm2 pm2-runtime /opt/server/chompchain-node/nodes/ecosystem.config.js --only "validator, registry"
+pm2-runtime /opt/server/chompchain-node/nodes/ecosystem.config.js --only "validator, registry"


### PR DESCRIPTION
This approach makes group write "sticky" on `/mempool`.