### PR TITLE
Take away chompers' copy of cron job

### DIFF
--- a/images/full-node/Dockerfile
+++ b/images/full-node/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -y apt-utils \
     dpkg \
     sudo \
     gosu \
+    nano \
     rsyslog \
     apt-transport-https \
     gnupg \
@@ -99,7 +100,6 @@ RUN usermod -aG chain chompers
 
 ADD crontab /etc/cron.d/sweep-transactions
 RUN chmod 644 /etc/cron.d/sweep-transactions
-RUN gosu chompers crontab /etc/cron.d/sweep-transactions
 
 ADD entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/images/full-node/crontab
+++ b/images/full-node/crontab
@@ -1,1 +1,1 @@
-* * * * * chompers bash -c 'source ~/.bashrc && chompchain --generate'
+* * * * * chompers bash -c 'source /home/chompers/.bashrc && chompchain --generate'


### PR DESCRIPTION
Add `nano` for troubleshooting, take job away from `chompers` user.