### PR TITLE
Update cron command to run full path to binary

### DIFF
--- a/images/full-node/crontab
+++ b/images/full-node/crontab
@@ -1,1 +1,1 @@
-* * * * * chompers bash -c 'source /home/chompers/.bashrc && chompchain --generate'
+* * * * * chompers bash -c 'source /home/chompers/.bashrc && /usr/local/bin/chompchain --generate'


### PR DESCRIPTION
The `cron` job needs the full path to the chompchain binary in `/usr/local/bin`.